### PR TITLE
feat: add query hint flag option

### DIFF
--- a/src/delta_sharing_client.cpp
+++ b/src/delta_sharing_client.cpp
@@ -52,6 +52,12 @@ DeltaSharingProfile DeltaSharingProfile::FromConfig(ClientContext &context) {
         profile.expiration_time = expiration_value.ToString();
     }
 
+    Value query_hints_value;
+    if (context.TryGetCurrentSetting("delta_sharing_enable_query_hints", query_hints_value) &&
+        !query_hints_value.IsNull()) {
+        profile.enable_query_hints = query_hints_value.GetValue<bool>();
+    }
+
     // Remove trailing slash from endpoint if present
     if (!profile.endpoint.empty() && profile.endpoint.back() == '/') {
         profile.endpoint.pop_back();
@@ -374,7 +380,8 @@ DeltaSharingClient::QueryTableResult DeltaSharingClient::QueryTable(
     const std::string &table_name,
     const JsonValue &predicate_hints,
     int64_t limit_hint,
-    int64_t version) {
+    int64_t version,
+    const std::string &query_hint) {
 
     // Build POST request body
     json request_body;
@@ -389,6 +396,9 @@ DeltaSharingClient::QueryTableResult DeltaSharingClient::QueryTable(
     }
     if (version > 0) {
         request_body["version"] = version;
+    }
+    if (!query_hint.empty()) {
+        request_body["queryHint"] = query_hint;
     }
 
     std::string post_data = request_body.dump();

--- a/src/duck_delta_share_extension.cpp
+++ b/src/duck_delta_share_extension.cpp
@@ -167,11 +167,20 @@ static unique_ptr<GlobalTableFunctionState> ReadDeltaShareInit(
 
     DeltaSharingProfile profile = DeltaSharingProfile::FromConfig(context);
     DeltaSharingClient client(profile);
+
+    std::string query_hint = "";
+    if (profile.enable_query_hints) {
+        query_hint = context.GetCurrentQuery();
+    }
+
     auto query_result = client.QueryTable(
         bind_data.share_name,
         bind_data.schema_name,
         bind_data.table_name,
-        bind_data.predicate_hints
+        bind_data.predicate_hints,
+        -1, // limit_hint
+        -1, // version
+        query_hint
     );
     bind_data.files = query_result.files;
     bind_data.metadata = query_result.metadata;
@@ -369,9 +378,14 @@ static void DeltaShareListFilesFunction(
             DeltaSharingProfile profile = DeltaSharingProfile::FromConfig(context);
             DeltaSharingClient client(profile);
 
+            std::string query_hint = "";
+            if (profile.enable_query_hints) {
+                query_hint = context.GetCurrentQuery();
+            }
+
             // Query table to get files
             auto query_result = client.QueryTable(
-                share_name, schema_name, table_name, predicate_hints);
+                share_name, schema_name, table_name, predicate_hints, -1, -1, query_hint);
 
             // Set list entry metadata
             list_data[row_idx].offset = total_size;
@@ -417,6 +431,9 @@ static void LoadInternal(ExtensionLoader &loader) {
     config.AddExtensionOption("delta_sharing_bearer_token", "JWT Bearer token issued from server", 
         LogicalType::VARCHAR, 
         env_token? std::string(env_token) : "");
+    config.AddExtensionOption("delta_sharing_enable_query_hints", "Enable passing DuckDB query to Delta Sharing Server", 
+        LogicalType::BOOLEAN, 
+        Value::BOOLEAN(false));
 
     // Delta Sharing Functions
     TableFunction list("delta_share_list", {}, ListFunction, ListBind);

--- a/src/include/delta_sharing_client.hpp
+++ b/src/include/delta_sharing_client.hpp
@@ -14,6 +14,7 @@ struct DeltaSharingProfile {
     std::string endpoint;
     std::string bearer_token;
     std::string expiration_time; // Optional, ISO 8601 format
+    bool enable_query_hints = false;
 
     static DeltaSharingProfile FromConfig(ClientContext &context);
 };
@@ -120,7 +121,8 @@ public:
         const std::string &table_name,
         const JsonValue &predicate_hints = JsonValue::Object(),
         int64_t limit_hint = -1,
-        int64_t version = -1);
+        int64_t version = -1,
+        const std::string &query_hint = "");
 
 private:
     DeltaSharingProfile profile_;


### PR DESCRIPTION
## Summary of Changes

- [x] Add a DuckDB setting `enable_query_hints` that when enabled, has the requests the the `tables/query` endpoint include the original DuckDB query

Its useful for us to be able to pass through the DuckDB query to our own custom server for further pushdown optimizations we might want to support. Its not spec compliant but I made it a default off option so that servers can support it as needed. 